### PR TITLE
Add flip card reveal for guess cells

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,20 +85,23 @@ function intentarAdivinar() {
 
   const fila = document.createElement("tr");
 
-  fila.innerHTML = `
-    <td class="imagen-nombre">
-      <div class="cuadro-icono">
+  const celdaNombre = crearFlipCell(
+    `<div class="cuadro-icono">
         <img src="img/${mineral.nombre.toLowerCase()}.png" alt="${mineral.nombre}" />
         <span>${capitalizar(mineral.nombre)}</span>
-      </div>
-    </td>
-    <td class="${compararClase(mineral.dureza, mineralDelDia.dureza)}">${mineral.dureza}</td>
-    <td class="${compararClase(mineral.sistema, mineralDelDia.sistema)}">${mineral.sistema.join(", ")}</td>
-    <td class="${compararClase(mineral.brillo, mineralDelDia.brillo)}">${mineral.brillo.join(", ")}</td>
-    <td class="${compararClase(mineral.grupo, mineralDelDia.grupo)}">${mineral.grupo.join(", ")}</td>
-  `;
+     </div>`,
+    "",
+    "imagen-nombre"
+  );
+  fila.appendChild(celdaNombre);
+
+  fila.appendChild(crearFlipCell(mineral.dureza, compararClase(mineral.dureza, mineralDelDia.dureza)));
+  fila.appendChild(crearFlipCell(mineral.sistema.join(", "), compararClase(mineral.sistema, mineralDelDia.sistema)));
+  fila.appendChild(crearFlipCell(mineral.brillo.join(", "), compararClase(mineral.brillo, mineralDelDia.brillo)));
+  fila.appendChild(crearFlipCell(mineral.grupo.join(", "), compararClase(mineral.grupo, mineralDelDia.grupo)));
 
   document.getElementById("tabla-cuerpo").appendChild(fila);
+  revealRow(fila);
 
   intentos++;
   if (mineral.nombre === mineralDelDia.nombre) {
@@ -149,4 +152,35 @@ function comparar(valor, objetivo) {
 
 function capitalizar(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function crearFlipCell(contenido, colorClase = "", extra = "") {
+  const td = document.createElement("td");
+  td.className = `flip-card ${extra}`.trim();
+
+  const inner = document.createElement("div");
+  inner.className = "flip-card-inner";
+
+  const front = document.createElement("div");
+  front.className = "flip-card-front";
+  front.textContent = "?";
+
+  const back = document.createElement("div");
+  back.className = `flip-card-back ${colorClase}`.trim();
+  back.innerHTML = contenido;
+
+  inner.appendChild(front);
+  inner.appendChild(back);
+  td.appendChild(inner);
+
+  return td;
+}
+
+function revealRow(fila) {
+  const celdas = Array.from(fila.querySelectorAll(".flip-card"));
+  celdas.forEach((celda, idx) => {
+    setTimeout(() => {
+      celda.classList.add("flipped");
+    }, idx * 500);
+  });
 }

--- a/style.css
+++ b/style.css
@@ -87,11 +87,49 @@ input {
   text-align: center;
   vertical-align: middle;
   font-size: clamp(10px, 1.2vw, 16px);
-  padding: 0 4px;
+  padding: 0;
   box-sizing: border-box;
   overflow: hidden;
   word-break: break-word;
   line-height: 1.1;
+}
+
+/* Flip card effect */
+.flip-card {
+  perspective: 600px;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.flip-card.flipped .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+}
+
+.flip-card-front {
+  background-color: #2a2a2a;
+  color: #fff;
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
 }
 
 /* Nombre + Imagen en una sola celda */


### PR DESCRIPTION
## Summary
- animate guess result table with flip-card style
- add helper utilities to build and reveal flip cards
- tweak result cell padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866b71337448333a84563b2909d1c58