### PR TITLE
Expand mineral properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,10 +30,12 @@
   <thead>
     <tr>
       <th></th>
-      <th>Dureza</th>
-      <th>Sistema</th>
-      <th>Brillo</th>
-      <th>Grupo</th>
+      <th id="th-grupo">Grupo</th>
+      <th id="th-sistema">Sistema</th>
+      <th id="th-color">Color</th>
+      <th id="th-brillo">Brillo</th>
+      <th id="th-dureza">Dureza</th>
+      <th id="th-densidad">Densidad</th>
     </tr>
   </thead>
   <tbody id="tabla-cuerpo">

--- a/lang/en.json
+++ b/lang/en.json
@@ -3,10 +3,12 @@
   "input_placeholder": "Type a mineral...",
   "boton_adivinar": "Guess",
   "propiedades": {
-    "dureza": "Hardness",
+    "grupo": "Group",
     "sistema": "Crystal system",
+    "color": "Color",
     "brillo": "Luster",
-    "grupo": "Group"
+    "dureza": "Hardness",
+    "densidad": "Density"
   },
   "mensajes": {
     "correcto": "Correct! The mineral of the day was:",

--- a/lang/es.json
+++ b/lang/es.json
@@ -3,10 +3,12 @@
   "input_placeholder": "Escribe un mineral...",
   "boton_adivinar": "Adivinar",
   "propiedades": {
-    "dureza": "Dureza",
+    "grupo": "Grupo",
     "sistema": "Sistema cristalino",
+    "color": "Color",
     "brillo": "Brillo",
-    "grupo": "Grupo"
+    "dureza": "Dureza",
+    "densidad": "Densidad"
   },
   "mensajes": {
     "correcto": "¡Correcto! Has adivinado el mineral del día:",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -3,10 +3,12 @@
   "input_placeholder": "鉱物の名前を入力...",
   "boton_adivinar": "予想する",
   "propiedades": {
-    "dureza": "硬度",
+    "grupo": "グループ",
     "sistema": "結晶系",
+    "color": "色",
     "brillo": "光沢",
-    "grupo": "グループ"
+    "dureza": "硬度",
+    "densidad": "密度"
   },
   "mensajes": {
     "correcto": "正解！本日の鉱物は：",

--- a/minerales.json
+++ b/minerales.json
@@ -1,29 +1,110 @@
 [
   {
     "nombre": "Cuarzo",
+    "grupo": ["Tectosilicatos"],
+    "sistema": ["Trigonal", "Hexagonal"],
+    "color": ["Incoloro", "Blanco", "Morado"],
+    "brillo": ["Vítreo"],
     "dureza": 7,
-    "sistema": [
-      "Trigonal",
-      "Hexagonal"
-    ],
-    "brillo": [
-      "Vítreo","Metálico"
-    ],
-    "grupo": [
-      "Tectosilicatos"
-    ]
+    "densidad": 2.65
   },
   {
     "nombre": "Pirita",
+    "grupo": ["Sulfuros"],
+    "sistema": ["Cúbico", "Hexagonal"],
+    "color": ["Dorado"],
+    "brillo": ["Metálico"],
     "dureza": 6,
-    "sistema": [
-      "Cúbico", "Hexagonal"
-    ],
-    "brillo": [
-      "Metálico"
-    ],
-    "grupo": [
-      "Sulfuros"
-    ]
+    "densidad": 5.0
+  },
+  {
+    "nombre": "Calcita",
+    "grupo": ["Carbonatos"],
+    "sistema": ["Trigonal"],
+    "color": ["Blanco", "Incoloro"],
+    "brillo": ["Vítreo", "Nacarado"],
+    "dureza": 3,
+    "densidad": 2.71
+  },
+  {
+    "nombre": "Feldespato",
+    "grupo": ["Tectosilicatos"],
+    "sistema": ["Monoclínico", "Triclínico"],
+    "color": ["Rosa", "Blanco"],
+    "brillo": ["Vítreo", "Perlado"],
+    "dureza": 6,
+    "densidad": 2.55
+  },
+  {
+    "nombre": "Galena",
+    "grupo": ["Sulfuros"],
+    "sistema": ["Cúbico"],
+    "color": ["Gris", "Plata"],
+    "brillo": ["Metálico"],
+    "dureza": 2,
+    "densidad": 7.6
+  },
+  {
+    "nombre": "Malaquita",
+    "grupo": ["Carbonatos"],
+    "sistema": ["Monoclínico"],
+    "color": ["Verde"],
+    "brillo": ["Vítreo", "Terroso"],
+    "dureza": 3.5,
+    "densidad": 4.0
+  },
+  {
+    "nombre": "Hematita",
+    "grupo": ["Óxidos"],
+    "sistema": ["Trigonal"],
+    "color": ["Rojo", "Negro"],
+    "brillo": ["Metálico", "Terroso"],
+    "dureza": 6,
+    "densidad": 5.3
+  },
+  {
+    "nombre": "Fluorita",
+    "grupo": ["Haluros"],
+    "sistema": ["Cúbico"],
+    "color": ["Violeta", "Verde"],
+    "brillo": ["Vítreo"],
+    "dureza": 4,
+    "densidad": 3.18
+  },
+  {
+    "nombre": "Magnetita",
+    "grupo": ["Óxidos"],
+    "sistema": ["Cúbico"],
+    "color": ["Negro"],
+    "brillo": ["Metálico"],
+    "dureza": 5.5,
+    "densidad": 5.17
+  },
+  {
+    "nombre": "Azurita",
+    "grupo": ["Carbonatos"],
+    "sistema": ["Monoclínico"],
+    "color": ["Azul"],
+    "brillo": ["Vítreo"],
+    "dureza": 3.5,
+    "densidad": 3.77
+  },
+  {
+    "nombre": "Olivino",
+    "grupo": ["Nesosilicatos"],
+    "sistema": ["Ortorrómbico"],
+    "color": ["Verde", "Amarillo"],
+    "brillo": ["Vítreo"],
+    "dureza": 6.5,
+    "densidad": 3.33
+  },
+  {
+    "nombre": "Crisocola",
+    "grupo": ["Filosilicatos"],
+    "sistema": ["Ortorrómbico"],
+    "color": ["Azul", "Verde"],
+    "brillo": ["Mate"],
+    "dureza": 2.5,
+    "densidad": 2.12
   }
 ]

--- a/script.js
+++ b/script.js
@@ -21,6 +21,14 @@ function aplicarTraducciones() {
   document.getElementById("titulo").innerText = traducciones.titulo || "Mineraldle";
   document.getElementById("inputMineral").placeholder = traducciones.input_placeholder || "Escribe un mineral...";
   document.getElementById("btnAdivinar").innerText = traducciones.boton_adivinar || "Adivinar";
+  if (traducciones.propiedades) {
+    document.getElementById("th-grupo").innerText = traducciones.propiedades.grupo || "Grupo";
+    document.getElementById("th-sistema").innerText = traducciones.propiedades.sistema || "Sistema";
+    document.getElementById("th-color").innerText = traducciones.propiedades.color || "Color";
+    document.getElementById("th-brillo").innerText = traducciones.propiedades.brillo || "Brillo";
+    document.getElementById("th-dureza").innerText = traducciones.propiedades.dureza || "Dureza";
+    document.getElementById("th-densidad").innerText = traducciones.propiedades.densidad || "Densidad";
+  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -95,10 +103,12 @@ function intentarAdivinar() {
   );
   fila.appendChild(celdaNombre);
 
-  fila.appendChild(crearFlipCell(mineral.dureza, compararClase(mineral.dureza, mineralDelDia.dureza)));
-  fila.appendChild(crearFlipCell(mineral.sistema.join(", "), compararClase(mineral.sistema, mineralDelDia.sistema)));
-  fila.appendChild(crearFlipCell(mineral.brillo.join(", "), compararClase(mineral.brillo, mineralDelDia.brillo)));
   fila.appendChild(crearFlipCell(mineral.grupo.join(", "), compararClase(mineral.grupo, mineralDelDia.grupo)));
+  fila.appendChild(crearFlipCell(mineral.sistema.join(", "), compararClase(mineral.sistema, mineralDelDia.sistema)));
+  fila.appendChild(crearFlipCell(mineral.color.join(", "), compararClase(mineral.color, mineralDelDia.color)));
+  fila.appendChild(crearFlipCell(mineral.brillo.join(", "), compararClase(mineral.brillo, mineralDelDia.brillo)));
+  fila.appendChild(crearFlipCell(mineral.dureza, compararClase(mineral.dureza, mineralDelDia.dureza)));
+  fila.appendChild(crearFlipCell(mineral.densidad, compararClase(mineral.densidad, mineralDelDia.densidad)));
 
   document.getElementById("tabla-cuerpo").appendChild(fila);
   revealRow(fila);


### PR DESCRIPTION
## Summary
- expand language files with new properties
- add 10 additional minerals and include color and intensity fields
- update table headers for the new guessing order
- update JS logic to handle new properties and translated headers

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('minerales.json','utf8')); console.log('JSON valid');"`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6866bdea3dfc83339bb9274b05990bdc