### PR TITLE
Add mineral value translations

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -13,5 +13,55 @@
   "mensajes": {
     "correcto": "Correct! The mineral of the day was:",
     "fallo": "You're out of guesses. It was:"
+  },
+  "valores": {
+    "cuarzo": "Quartz",
+    "pirita": "Pyrite",
+    "calcita": "Calcite",
+    "feldespato": "Feldspar",
+    "galena": "Galena",
+    "malaquita": "Malachite",
+    "hematita": "Hematite",
+    "fluorita": "Fluorite",
+    "magnetita": "Magnetite",
+    "azurita": "Azurite",
+    "olivino": "Olivine",
+    "crisocola": "Chrysocolla",
+
+    "tectosilicatos": "Tectosilicates",
+    "sulfuros": "Sulfides",
+    "carbonatos": "Carbonates",
+    "\u00f3xidos": "Oxides",
+    "haluros": "Halides",
+    "nesosilicatos": "Nesosilicates",
+    "filosilicatos": "Phyllosilicates",
+
+    "trigonal": "Trigonal",
+    "hexagonal": "Hexagonal",
+    "monocl\u00ednico": "Monoclinic",
+    "tricl\u00ednico": "Triclinic",
+    "c\u00fabico": "Cubic",
+    "ortorr\u00f3mbico": "Orthorhombic",
+
+    "incoloro": "Colorless",
+    "blanco": "White",
+    "morado": "Purple",
+    "dorado": "Golden",
+    "rosa": "Pink",
+    "gris": "Gray",
+    "plata": "Silver",
+    "verde": "Green",
+    "rojo": "Red",
+    "negro": "Black",
+    "violeta": "Violet",
+    "amarillo": "Yellow",
+    "azul": "Blue",
+
+    "v\u00edtreo": "Vitreous",
+    "met\u00e1lico": "Metallic",
+    "nacarado": "Pearly",
+    "perlado": "Pearly",
+    "terroso": "Earthy",
+    "mate": "Dull"
   }
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -13,5 +13,6 @@
   "mensajes": {
     "correcto": "¡Correcto! Has adivinado el mineral del día:",
     "fallo": "Te has quedado sin intentos. Era:"
-  }
+  },
+  "valores": {}
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -13,5 +13,55 @@
   "mensajes": {
     "correcto": "正解！本日の鉱物は：",
     "fallo": "試行回数が終了しました。正解は："
+  },
+  "valores": {
+    "cuarzo": "石英",
+    "pirita": "黄鉄鉱",
+    "calcita": "方解石",
+    "feldespato": "長石",
+    "galena": "方鉛鉱",
+    "malaquita": "マラカイト",
+    "hematita": "赤鉄鉱",
+    "fluorita": "蛍石",
+    "magnetita": "磁鉄鉱",
+    "azurita": "アズライト",
+    "olivino": "カンラン石",
+    "crisocola": "クリソコラ",
+
+    "tectosilicatos": "テクトケイ酸塩",
+    "sulfuros": "硫化物",
+    "carbonatos": "炭酸塩",
+    "\u00f3xidos": "酸化物",
+    "haluros": "ハロゲン化物",
+    "nesosilicatos": "ネソケイ酸塩",
+    "filosilicatos": "フィロケイ酸塩",
+
+    "trigonal": "三方晶系",
+    "hexagonal": "六方晶系",
+    "monocl\u00ednico": "単斜晶系",
+    "tricl\u00ednico": "三斜晶系",
+    "c\u00fabico": "等軸晶系",
+    "ortorr\u00f3mbico": "斜方晶系",
+
+    "incoloro": "無色",
+    "blanco": "白",
+    "morado": "紫",
+    "dorado": "金色",
+    "rosa": "ピンク",
+    "gris": "灰色",
+    "plata": "銀色",
+    "verde": "緑",
+    "rojo": "赤",
+    "negro": "黒",
+    "violeta": "バイオレット",
+    "amarillo": "黄色",
+    "azul": "青",
+
+    "v\u00edtreo": "ガラス光沢",
+    "met\u00e1lico": "金属光沢",
+    "nacarado": "真珠光沢",
+    "perlado": "真珠光沢",
+    "terroso": "土状光沢",
+    "mate": "無光沢"
   }
 }

--- a/script.js
+++ b/script.js
@@ -6,6 +6,15 @@ const maxIntentos = 6;
 let minerales = [];
 let cabeceraMostrada = false;
 
+function traducirValor(valor) {
+  const key = String(valor).toLowerCase();
+  return (traducciones.valores && traducciones.valores[key]) || valor;
+}
+
+function traducirLista(arr) {
+  return arr.map(traducirValor);
+}
+
 function setIdioma(idioma) {
   fetch(`lang/${idioma}.json`)
     .then(res => res.json())
@@ -95,18 +104,38 @@ function intentarAdivinar() {
 
   const celdaNombre = crearFlipCell(
     `<div class="cuadro-icono">
-        <img src="img/${mineral.nombre.toLowerCase()}.png" alt="${mineral.nombre}" />
-        <span>${capitalizar(mineral.nombre)}</span>
+        <img src="img/${mineral.nombre.toLowerCase()}.png" alt="${traducirValor(mineral.nombre)}" />
+        <span>${traducirValor(mineral.nombre)}</span>
      </div>`,
     "",
     "imagen-nombre"
   );
   fila.appendChild(celdaNombre);
 
-  fila.appendChild(crearFlipCell(mineral.grupo.join(", "), compararClase(mineral.grupo, mineralDelDia.grupo)));
-  fila.appendChild(crearFlipCell(mineral.sistema.join(", "), compararClase(mineral.sistema, mineralDelDia.sistema)));
-  fila.appendChild(crearFlipCell(mineral.color.join(", "), compararClase(mineral.color, mineralDelDia.color)));
-  fila.appendChild(crearFlipCell(mineral.brillo.join(", "), compararClase(mineral.brillo, mineralDelDia.brillo)));
+  fila.appendChild(
+    crearFlipCell(
+      traducirLista(mineral.grupo).join(", "),
+      compararClase(mineral.grupo, mineralDelDia.grupo)
+    )
+  );
+  fila.appendChild(
+    crearFlipCell(
+      traducirLista(mineral.sistema).join(", "),
+      compararClase(mineral.sistema, mineralDelDia.sistema)
+    )
+  );
+  fila.appendChild(
+    crearFlipCell(
+      traducirLista(mineral.color).join(", "),
+      compararClase(mineral.color, mineralDelDia.color)
+    )
+  );
+  fila.appendChild(
+    crearFlipCell(
+      traducirLista(mineral.brillo).join(", "),
+      compararClase(mineral.brillo, mineralDelDia.brillo)
+    )
+  );
   fila.appendChild(crearFlipCell(mineral.dureza, compararClase(mineral.dureza, mineralDelDia.dureza)));
   fila.appendChild(crearFlipCell(mineral.densidad, compararClase(mineral.densidad, mineralDelDia.densidad)));
 
@@ -116,9 +145,15 @@ function intentarAdivinar() {
 
   intentos++;
   if (mineral.nombre === mineralDelDia.nombre) {
-    document.getElementById("resultado").innerText = (traducciones.mensajes?.correcto || "¡Correcto!") + " " + mineralDelDia.nombre;
+    document.getElementById("resultado").innerText =
+      (traducciones.mensajes?.correcto || "¡Correcto!") +
+      " " +
+      traducirValor(mineralDelDia.nombre);
   } else if (intentos >= maxIntentos) {
-    document.getElementById("resultado").innerText = (traducciones.mensajes?.fallo || "Has fallado.") + " " + mineralDelDia.nombre;
+    document.getElementById("resultado").innerText =
+      (traducciones.mensajes?.fallo || "Has fallado.") +
+      " " +
+      traducirValor(mineralDelDia.nombre);
   }
 }
 


### PR DESCRIPTION
## Summary
- provide translations for mineral names and category values in English and Japanese
- expose translation entries through new `valores` section in language files
- translate mineral values in result rows and result messages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866c5e221c88333bec4b26690bf4dda