### PR TITLE
Add win/lose modal with counter and fireworks

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,14 @@
     <button onclick="setIdioma('ja')">🇯🇵</button>
   </div>
 
-  <div class="autocomplete-container">
-  <input id="inputMineral" placeholder="Escribe un mineral..." autocomplete="off" />
-  <ul id="autocomplete-list" class="autocomplete-items"></ul>
-</div>
-
-  <button id="btnAdivinar">Adivinar</button>
+  <div id="form-container">
+    <div id="counter"><span id="counter-label"></span><span id="counter-value"></span></div>
+    <div class="autocomplete-container">
+      <input id="inputMineral" placeholder="Escribe un mineral..." autocomplete="off" />
+      <ul id="autocomplete-list" class="autocomplete-items"></ul>
+    </div>
+    <button id="btnAdivinar">Adivinar</button>
+  </div>
 
   <div id="contenedor-tabla">
   <table class="tabla-resultados" id="tablaResultados">
@@ -45,5 +47,17 @@
 
   <div id="resultado"></div>
   <div id="pistas"></div>
+
+  <div id="modal" class="hidden">
+    <div class="modal-content">
+      <span id="close-modal" class="close">&times;</span>
+      <h2 id="modal-title"></h2>
+      <p id="modal-mineral"></p>
+      <img id="modal-img" src="" alt="">
+      <p id="modal-intentos"></p>
+    </div>
+  </div>
+
+  <div id="fireworks" class="hidden">🎆</div>
 </body>
 </html>

--- a/lang/en.json
+++ b/lang/en.json
@@ -12,7 +12,12 @@
   },
   "mensajes": {
     "correcto": "Correct! The mineral of the day was:",
-    "fallo": "You're out of guesses. It was:"
+    "fallo": "You're out of guesses. It was:",
+    "ganaste_titulo": "YOU WON!",
+    "perdiste_titulo": "GAME OVER",
+    "mineral_era": "The mineral was:",
+    "intentos": "Tries:",
+    "intentos_restantes": "Tries left:"
   },
   "valores": {
     "cuarzo": "Quartz",

--- a/lang/es.json
+++ b/lang/es.json
@@ -12,7 +12,12 @@
   },
   "mensajes": {
     "correcto": "¡Correcto! Has adivinado el mineral del día:",
-    "fallo": "Te has quedado sin intentos. Era:"
+    "fallo": "Te has quedado sin intentos. Era:",
+    "ganaste_titulo": "\u00a1GANASTE!",
+    "perdiste_titulo": "GAME OVER",
+    "mineral_era": "El mineral era:",
+    "intentos": "Intentos:",
+    "intentos_restantes": "Intentos restantes:"
   },
   "valores": {}
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -12,7 +12,12 @@
   },
   "mensajes": {
     "correcto": "正解！本日の鉱物は：",
-    "fallo": "試行回数が終了しました。正解は："
+    "fallo": "試行回数が終了しました。正解は：",
+    "ganaste_titulo": "\u304a\u3081\u3067\u3068\u3046\uff01",
+    "perdiste_titulo": "GAME OVER",
+    "mineral_era": "\u92fc\u7269\u306f:",
+    "intentos": "\u8a66\u884c\u56de\u6570:",
+    "intentos_restantes": "\u6b8b\u308a\u56de\u6570:"
   },
   "valores": {
     "cuarzo": "石英",

--- a/style.css
+++ b/style.css
@@ -258,8 +258,78 @@ input {
     height: 30px;
   }
 
+}
 
+/* Form and counter */
+#form-container {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+}
 
+#counter {
+  font-size: 1.2em;
+  white-space: nowrap;
+}
 
-  
+#fireworks {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 5rem;
+  pointer-events: none;
+  animation: fadeOut 2s forwards;
+  z-index: 1500;
+}
+
+@keyframes fadeOut {
+  0% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+#modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+#modal.hidden,
+#fireworks.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #2a2a2a;
+  padding: 1em 2em;
+  border-radius: 10px;
+  position: relative;
+  text-align: center;
+}
+
+.modal-content img {
+  max-width: 200px;
+  border: 4px solid #fff;
+  border-radius: 8px;
+  margin: 1em 0;
+}
+
+.close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+  font-size: 1.5em;
 }


### PR DESCRIPTION
## Summary
- expand allowed guesses to 10
- show remaining attempts next to the input
- block further guesses when attempts run out or mineral is found
- play simple fireworks and show modal with win/lose info and mineral picture
- add translations for the new texts

## Testing
- `python3 -m json.tool lang/es.json >/tmp/check_es.json`
- `python3 -m json.tool lang/en.json >/tmp/check_en.json`
- `python3 -m json.tool lang/ja.json >/tmp/check_ja.json`


------
https://chatgpt.com/codex/tasks/task_e_6866ccb375548333b794bd46a8686daa