### PR TITLE
Fix attempt counter timing

### DIFF
--- a/script.js
+++ b/script.js
@@ -134,7 +134,7 @@ function iniciarAutocompletado() {
 }
 
 async function intentarAdivinar() {
-  if (juegoTerminado) return;
+  if (juegoTerminado || intentos >= maxIntentos) return;
   const input = document.getElementById("inputMineral").value.trim().toLowerCase();
   const mineral = minerales.find(m => m.nombre.toLowerCase() === input);
   if (!mineral) {
@@ -142,10 +142,15 @@ async function intentarAdivinar() {
     return;
   }
 
+  intentos++;
+  updateCounter();
+  const numeroIntento = intentos;
+
   const fila = document.createElement("tr");
 
   const celdaNombre = crearFlipCell(
     `<div class="cuadro-icono">
+        <span class="numero-intento">#${numeroIntento}</span>
         <img src="img/${mineral.nombre.toLowerCase()}.png" alt="${traducirValor(mineral.nombre)}" />
         <span>${traducirValor(mineral.nombre)}</span>
      </div>`,
@@ -185,8 +190,6 @@ async function intentarAdivinar() {
   cuerpo.insertBefore(fila, cuerpo.firstChild);
   await revealRow(fila);
 
-  intentos++;
-  updateCounter();
   const gano = mineral.nombre === mineralDelDia.nombre;
   if (gano || intentos >= maxIntentos) {
     juegoTerminado = true;

--- a/style.css
+++ b/style.css
@@ -142,8 +142,26 @@ input {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  position: relative;
   height: 80px;
   width: 80px;
+}
+
+.numero-intento {
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #444;
+  color: #fff;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  font-size: 0.75em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #000;
 }
 
 .cuadro-icono img {


### PR DESCRIPTION
## Summary
- reduce spamming exploits by consuming a try when the Guess button is pressed
- display current attempt number in the guess cell
- style the new attempt number tag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866cf8b4e108333aa5d86b69db8958f