### PR TITLE
Fix attempt number visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -150,13 +150,16 @@ async function intentarAdivinar() {
 
   const celdaNombre = crearFlipCell(
     `<div class="cuadro-icono">
-        <span class="numero-intento">#${numeroIntento}</span>
         <img src="img/${mineral.nombre.toLowerCase()}.png" alt="${traducirValor(mineral.nombre)}" />
         <span>${traducirValor(mineral.nombre)}</span>
      </div>`,
     "",
     "imagen-nombre"
   );
+  const spanNum = document.createElement("span");
+  spanNum.className = "numero-intento";
+  spanNum.textContent = `#${numeroIntento}`;
+  celdaNombre.appendChild(spanNum);
   fila.appendChild(celdaNombre);
 
   fila.appendChild(

--- a/style.css
+++ b/style.css
@@ -135,6 +135,8 @@ input {
 /* Nombre + Imagen en una sola celda */
 .imagen-nombre {
   padding: 0;
+  position: relative;
+  overflow: visible;
 }
 
 .cuadro-icono {
@@ -149,7 +151,7 @@ input {
 
 .numero-intento {
   position: absolute;
-  left: -10px;
+  left: -26px;
   top: 50%;
   transform: translateY(-50%);
   background: #444;
@@ -162,6 +164,7 @@ input {
   align-items: center;
   justify-content: center;
   border: 2px solid #000;
+  z-index: 10;
 }
 
 .cuadro-icono img {


### PR DESCRIPTION
## Summary
- ensure first table cell can show elements outside its bounds
- move attempt number element outside the flip card in the first column

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6866d1231fb083338b4d52f8cd4eae6b