### PR TITLE
Fix mobile table layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,8 +60,13 @@ input {
 }
 
 /* NUEVO: Estilo general para la tabla de resultados */
-.tabla-resultados {
+#contenedor-tabla {
   width: 100%;
+  overflow-x: auto;
+}
+
+.tabla-resultados {
+  width: max-content;
   border-collapse: separate;
   border-spacing: 6px;
   font-size: 0.95em;


### PR DESCRIPTION
## Summary
- ensure results grid keeps square cells on small screens by allowing horizontal scroll

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866ea0aa2948333b89515acc5deefe1