### PR TITLE
Add directional arrow hints

### DIFF
--- a/script.js
+++ b/script.js
@@ -203,7 +203,7 @@ async function intentarAdivinar() {
     crearFlipCell(
       mineral.dureza,
       compararClase(mineral.dureza, mineralDelDia.dureza),
-      "",
+      direccionFlecha(mineral.dureza, mineralDelDia.dureza),
       mineral.dureza
     )
   );
@@ -211,7 +211,7 @@ async function intentarAdivinar() {
     crearFlipCell(
       mineral.densidad,
       compararClase(mineral.densidad, mineralDelDia.densidad),
-      "",
+      direccionFlecha(mineral.densidad, mineralDelDia.densidad),
       mineral.densidad
     )
   );
@@ -265,6 +265,16 @@ function compararClase(valor, objetivo) {
   if (conjuntosIguales) return "verde";
   if (coincidencias.length > 0) return "amarillo";
   return "rojo";
+}
+
+function direccionFlecha(valor, objetivo) {
+  if (
+    isNaN(parseFloat(valor)) ||
+    isNaN(parseFloat(objetivo)) ||
+    parseFloat(valor) === parseFloat(objetivo)
+  )
+    return "";
+  return parseFloat(valor) < parseFloat(objetivo) ? "arrow-up" : "arrow-down";
 }
 
 

--- a/style.css
+++ b/style.css
@@ -132,6 +132,33 @@ input {
 
 .flip-card-back {
   transform: rotateY(180deg);
+  position: relative;
+}
+
+.flip-card-back * {
+  position: relative;
+  z-index: 1;
+}
+
+td.arrow-up .flip-card-back::before,
+td.arrow-down .flip-card-back::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2em;
+  opacity: 0.2;
+  pointer-events: none;
+  z-index: 0;
+}
+
+td.arrow-up .flip-card-back::before {
+  content: "\2191";
+}
+
+td.arrow-down .flip-card-back::before {
+  content: "\2193";
 }
 
 /* Nombre + Imagen en una sola celda */


### PR DESCRIPTION
## Summary
- show arrows indicating if hardness or density guess is higher or lower
- update board CSS to display translucent arrows behind cell text

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866f581e9a4833390ae5ced660a1f4c