### PR TITLE
Improve arrow size and overlay text

### DIFF
--- a/script.js
+++ b/script.js
@@ -218,6 +218,7 @@ async function intentarAdivinar() {
 
   const cuerpo = document.getElementById("tabla-cuerpo");
   cuerpo.insertBefore(fila, cuerpo.firstChild);
+  ajustarTextoCeldas();
   await revealRow(fila);
 
   const gano = mineral.nombre === mineralDelDia.nombre;
@@ -365,6 +366,22 @@ function actualizarTraduccionesTabla() {
         back.innerHTML = nuevo;
       }
     });
+  });
+  ajustarTextoCeldas();
+}
+
+function ajustarTextoCeldas() {
+  const spans = document.querySelectorAll('.cuadro-icono span');
+  spans.forEach(span => {
+    span.style.fontSize = '';
+    const cont = span.parentElement;
+    if (!cont) return;
+    const max = cont.clientWidth - 4;
+    let size = parseFloat(getComputedStyle(span).fontSize);
+    while (span.scrollWidth > max && size > 5) {
+      size -= 0.5;
+      span.style.fontSize = size + 'px';
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -152,7 +152,7 @@ td.arrow-down .flip-card-back::before {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  font-size: 2em;
+  font-size: 6em;
   opacity: 0.2;
   pointer-events: none;
   z-index: 0;
@@ -174,15 +174,12 @@ td.arrow-down .flip-card-back::before {
 }
 
 .cuadro-icono {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   position: relative;
-  height: 80px;
   width: 80px;
+  height: 80px;
   min-width: 80px;
   min-height: 80px;
+  overflow: hidden;
 }
 
 .numero-intento {
@@ -204,23 +201,30 @@ td.arrow-down .flip-card-back::before {
 }
 
 .cuadro-icono img {
-  width: 48px;
-  height: 48px;
-  object-fit: contain;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   border-radius: 8px;
   border: 2px solid #000;
-  background-color: #fff;
-  margin-bottom: 2px;
 }
 
 .cuadro-icono span {
-  font-size: 0.75em;
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-size: 0.6em;
   text-align: center;
-  padding: 0 4px;
+  padding: 0 2px;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  overflow: hidden;
+  -webkit-text-stroke: 1px #000;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
 
 /* Colores de comparación */
@@ -318,9 +322,12 @@ td.arrow-down .flip-card-back::before {
     min-width: 60px;
     min-height: 60px;
   }
+  .cuadro-icono span {
+    font-size: 0.5em;
+  }
   .cuadro-icono img {
-    width: 30px;
-    height: 30px;
+    width: 100%;
+    height: 100%;
   }
 
 }


### PR DESCRIPTION
## Summary
- enlarge arrow indicators
- overlay mineral names on images with white text and black outline
- ensure images fill the square on both desktop and mobile

## Testing
- `npm test --silent` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fe21be0c83339006fde69da2e762