### PR TITLE
Adjust images to fill their containers

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,9 +16,11 @@ h1 {
 }
 
 #main-logo {
-  width: 500px;
+  width: 100%;
   height: auto;
+  max-width: none;
   margin-bottom: 0.5em;
+  object-fit: contain;
 }
 
 #language-selector {
@@ -384,7 +386,10 @@ td.arrow-down .flip-card-back::before {
 }
 
 .modal-content img {
-  max-width: 200px;
+  width: 100%;
+  height: auto;
+  max-width: none;
+  object-fit: contain;
   border: 4px solid #fff;
   border-radius: 8px;
   margin: 1em 0;
@@ -401,8 +406,8 @@ td.arrow-down .flip-card-back::before {
 /* Extra responsive tweaks */
 @media (max-width: 600px) {
   #main-logo {
-    width: 80%;
-    max-width: 300px;
+    width: 100%;
+    max-width: none;
   }
   #form-container {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- make main logo responsive and span full width
- allow modal images to occupy their full container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867096375f0833398a6f04147a48abd