### PR TITLE
Improve mobile font scaling

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,6 +79,7 @@ function aplicarTraducciones() {
   updateCounter();
   actualizarTraduccionesTabla();
   actualizarModalTraducciones();
+  ajustarTextoCeldas();
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/style.css
+++ b/style.css
@@ -312,13 +312,14 @@ td.arrow-down .flip-card-back::before {
     height: 60px;
     white-space: nowrap;
     overflow: hidden;
+    font-size: clamp(12px, 3vw, 18px);
   }
   .tabla-resultados td {
     width: 60px;
     height: 60px;
     min-width: 60px;
     min-height: 60px;
-    font-size: 0.9em;
+    font-size: clamp(12px, 4vw, 24px);
   }
   .cuadro-icono {
     width: 60px;
@@ -327,7 +328,7 @@ td.arrow-down .flip-card-back::before {
     min-height: 60px;
   }
   .cuadro-icono span {
-    font-size: 0.7em;
+    font-size: clamp(10px, 3vw, 18px);
   }
   .cuadro-icono img {
     width: 100%;


### PR DESCRIPTION
## Summary
- tweak mobile font sizes in table headers, cells, and mineral names
- resize text after loading translations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686721563b308333a9b008ffdf8a58cf