### PR TITLE
Add countdown timer and tweak mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
     <button id="btnAdivinar">Adivinar</button>
   </div>
 
+  <div id="timer"></div>
+
   <div id="contenedor-tabla">
   <table class="tabla-resultados" id="tablaResultados">
   <thead>

--- a/lang/en.json
+++ b/lang/en.json
@@ -17,7 +17,8 @@
     "perdiste_titulo": "GAME OVER",
     "mineral_era": "The mineral was:",
     "intentos": "Tries:",
-    "intentos_restantes": "Tries left:"
+    "intentos_restantes": "Tries left:",
+    "proximo_mineral": "Next mineral in:"
   },
   "valores": {
     "cuarzo": "Quartz",

--- a/lang/es.json
+++ b/lang/es.json
@@ -17,7 +17,8 @@
     "perdiste_titulo": "GAME OVER",
     "mineral_era": "El mineral era:",
     "intentos": "Intentos:",
-    "intentos_restantes": "Intentos restantes:"
+    "intentos_restantes": "Intentos restantes:",
+    "proximo_mineral": "Pr\u00f3ximo mineral en:"
   },
   "valores": {}
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -17,7 +17,8 @@
     "perdiste_titulo": "GAME OVER",
     "mineral_era": "\u92fc\u7269\u306f:",
     "intentos": "\u8a66\u884c\u56de\u6570:",
-    "intentos_restantes": "\u6b8b\u308a\u56de\u6570:"
+    "intentos_restantes": "\u6b8b\u308a\u56de\u6570:",
+    "proximo_mineral": "\u6b21\u306e\u92fc\u7269\u307e\u3067:"
   },
   "valores": {
     "cuarzo": "石英",

--- a/script.js
+++ b/script.js
@@ -7,6 +7,18 @@ let juegoTerminado = false;
 let minerales = [];
 let cabeceraMostrada = false;
 let ultimoResultado = null;
+let timerInterval = null;
+
+function updateTimer() {
+  const now = new Date();
+  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  const diff = tomorrow - now;
+  const h = String(Math.floor(diff / 3600000)).padStart(2, '0');
+  const m = String(Math.floor((diff % 3600000) / 60000)).padStart(2, '0');
+  const s = String(Math.floor((diff % 60000) / 1000)).padStart(2, '0');
+  const label = traducciones.mensajes?.proximo_mineral || 'Siguiente mineral en:';
+  document.getElementById('timer').innerText = `${label} ${h}:${m}:${s}`;
+}
 
 function updateCounter() {
   const valor = maxIntentos - intentos;
@@ -77,6 +89,7 @@ function aplicarTraducciones() {
   document.getElementById("counter-label").innerText =
     (traducciones.mensajes?.intentos_restantes || "Intentos: ");
   updateCounter();
+  updateTimer();
   actualizarTraduccionesTabla();
   actualizarModalTraducciones();
   ajustarTextoCeldas();
@@ -86,6 +99,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const guardado = localStorage.getItem("idioma") || "es";
   setIdioma(guardado);
   updateCounter();
+  updateTimer();
+  timerInterval = setInterval(updateTimer, 1000);
 
   fetch("minerales.json")
     .then(res => res.json())

--- a/style.css
+++ b/style.css
@@ -66,7 +66,7 @@ input {
 .tabla-resultados {
   border-collapse: separate;
   border-spacing: 6px;
-  font-size: 0.95em;
+  font-size: 1.1em; /* Tamaño base de fuente de la tabla; ajusta aquí */
   margin: 2em 0;
   table-layout: fixed;
 }
@@ -308,7 +308,7 @@ td.arrow-down .flip-card-back::before {
     font-size: 16px;
   }
   h1 {
-    font-size: 10em;
+    font-size: 2em;
   }
   .tabla-resultados thead th {
     width: 60px;
@@ -352,6 +352,11 @@ td.arrow-down .flip-card-back::before {
 #counter {
   font-size: 1.2em;
   white-space: nowrap;
+}
+
+#timer {
+  font-size: 1.2em;
+  margin-bottom: 0.5em;
 }
 
 #fireworks {


### PR DESCRIPTION
## Summary
- enlarge result table font size and add comment in CSS
- shrink mobile heading
- style timer section
- insert timer section in HTML
- implement countdown timer with translations
- add timer text to translation files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686854bab1dc8333b284c5fb6319a199