### PR TITLE
Fix header layout and cell sizing

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4,7 +4,7 @@
   "boton_adivinar": "Guess",
   "propiedades": {
     "grupo": "Group",
-    "sistema": "Crystal system",
+    "sistema": "Crystal<br>system",
     "color": "Color",
     "brillo": "Luster",
     "dureza": "Hardness",

--- a/lang/es.json
+++ b/lang/es.json
@@ -4,7 +4,7 @@
   "boton_adivinar": "Adivinar",
   "propiedades": {
     "grupo": "Grupo",
-    "sistema": "Sistema cristalino",
+    "sistema": "Sistema<br>Cristalino",
     "color": "Color",
     "brillo": "Brillo",
     "dureza": "Dureza",

--- a/script.js
+++ b/script.js
@@ -79,12 +79,12 @@ function aplicarTraducciones() {
   document.getElementById("inputMineral").placeholder = traducciones.input_placeholder || "Escribe un mineral...";
   document.getElementById("btnAdivinar").innerText = traducciones.boton_adivinar || "Adivinar";
   if (traducciones.propiedades) {
-    document.getElementById("th-grupo").innerText = traducciones.propiedades.grupo || "Grupo";
-    document.getElementById("th-sistema").innerText = traducciones.propiedades.sistema || "Sistema";
-    document.getElementById("th-color").innerText = traducciones.propiedades.color || "Color";
-    document.getElementById("th-brillo").innerText = traducciones.propiedades.brillo || "Brillo";
-    document.getElementById("th-dureza").innerText = traducciones.propiedades.dureza || "Dureza";
-    document.getElementById("th-densidad").innerText = traducciones.propiedades.densidad || "Densidad";
+    document.getElementById("th-grupo").innerHTML = traducciones.propiedades.grupo || "Grupo";
+    document.getElementById("th-sistema").innerHTML = traducciones.propiedades.sistema || "Sistema";
+    document.getElementById("th-color").innerHTML = traducciones.propiedades.color || "Color";
+    document.getElementById("th-brillo").innerHTML = traducciones.propiedades.brillo || "Brillo";
+    document.getElementById("th-dureza").innerHTML = traducciones.propiedades.dureza || "Dureza";
+    document.getElementById("th-densidad").innerHTML = traducciones.propiedades.densidad || "Densidad";
   }
   document.getElementById("counter-label").innerText =
     (traducciones.mensajes?.intentos_restantes || "Intentos: ");

--- a/style.css
+++ b/style.css
@@ -94,12 +94,16 @@ input {
   font-size: 1em;
   font-weight: normal;
   text-align: center;
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
   padding-bottom: 0.3em;
   border: none;
   width: 100px;
   min-width: 100px;
+  max-width: 100px;
   height: 100px;
+  min-height: 100px;
+  max-height: 100px;
   aspect-ratio: 1 / 1;
   overflow: hidden;
 }
@@ -110,6 +114,8 @@ input {
   height: 100px;
   min-width: 100px;
   min-height: 100px;
+  max-width: 100px;
+  max-height: 100px;
   aspect-ratio: 1 / 1;
   border: 3px solid #000;
   border-radius: 10px;
@@ -201,6 +207,8 @@ td.arrow-down .flip-card-back::before {
   height: 100px;
   min-width: 100px;
   min-height: 100px;
+  max-width: 100px;
+  max-height: 100px;
 }
 
 .numero-intento {
@@ -236,10 +244,10 @@ td.arrow-down .flip-card-back::before {
   transform: translateX(-50%);
   width: 100%;
   font-size: 1em;
-  color: #fff;
+  color: red;
   text-align: center;
   white-space: nowrap;
-  -webkit-text-stroke: 1px #000;
+  -webkit-text-stroke: 0;
   text-shadow: none;
 }
 
@@ -329,9 +337,13 @@ td.arrow-down .flip-card-back::before {
   .tabla-resultados thead th {
     width: 60px;
     min-width: 60px;
+    max-width: 60px;
     height: 60px;
+    min-height: 60px;
+    max-height: 60px;
     aspect-ratio: 1 / 1;
-    white-space: nowrap;
+    white-space: normal;
+    word-break: break-word;
     overflow: hidden;
     font-size: clamp(12px, 3vw, 18px);
   }
@@ -340,6 +352,8 @@ td.arrow-down .flip-card-back::before {
     height: 60px;
     min-width: 60px;
     min-height: 60px;
+    max-width: 60px;
+    max-height: 60px;
     aspect-ratio: 1 / 1;
     font-size: clamp(12px, 4vw, 24px);
   }
@@ -348,6 +362,8 @@ td.arrow-down .flip-card-back::before {
     height: 60px;
     min-width: 60px;
     min-height: 60px;
+    max-width: 60px;
+    max-height: 60px;
   }
   .cuadro-icono span {
     font-size: clamp(10px, 3vw, 18px);


### PR DESCRIPTION
## Summary
- allow HTML in header translation strings
- enforce square cell dimensions across the table
- tweak mineral name styling
- support header line breaks in translations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68686e42b9608333ba5f0e57c08d5eb4