### PR TITLE
Fix attempt counter placement and improve text resizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -413,16 +413,16 @@ function ajustarTextoCeldas() {
     let texto = el.innerText || el.textContent;
 
     // Dividir por comas en líneas nuevas
-    if (texto.includes(",")) {
-      el.innerHTML = texto.split(",").map(p => p.trim()).join("<br>");
+    if (texto.includes(',')) {
+      el.innerHTML = texto.split(',').map(p => p.trim()).join('<br>');
     }
 
     el.style.fontSize = '';
-    let size = parseFloat(getComputedStyle(el).fontSize);
-    const maxW = el.clientWidth - 6;
-    const maxH = el.clientHeight - 6;
-    const minSize = 10;
-    const maxSize = 40;
+    const minSize = 12;
+    const maxSize = 48;
+    let size = Math.max(parseFloat(getComputedStyle(el).fontSize), minSize);
+    const maxW = el.clientWidth - 4;
+    const maxH = el.clientHeight - 4;
 
     // Aumentar hasta que esté justo por debajo del máximo permitido
     while (el.scrollWidth < maxW && el.scrollHeight < maxH && size < maxSize) {

--- a/style.css
+++ b/style.css
@@ -213,15 +213,14 @@ td.arrow-down .flip-card-back::before {
 
 .numero-intento {
   position: absolute;
-  left: -26px;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 4px;
+  left: 4px;
+  width: 28px;
+  height: 28px;
+  font-size: 1rem;
   background: #444;
   color: #fff;
   border-radius: 50%;
-  width: 24px;
-  height: 24px;
-  font-size: 0.9em;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- tweak the style for the attempt number badge so it stays visible inside the cell
- adjust dynamic font sizing in `ajustarTextoCeldas` so text grows to nearly fill the cell

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686925655bbc83338c9c079646074969