### PR TITLE
Improve responsive text sizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -410,45 +410,36 @@ function actualizarTraduccionesTabla() {
 
 function ajustarTextoCeldas() {
   const ajustar = el => {
-    let texto = el.innerText || el.textContent;
+    let texto = el.textContent.trim();
 
-    // Dividir por comas en líneas nuevas
     if (texto.includes(',')) {
       el.innerHTML = texto.split(',').map(p => p.trim()).join('<br>');
+      texto = el.textContent.trim();
     }
 
-    el.style.fontSize = '';
     const minSize = 12;
-    const maxSize = 48;
-    const largo = texto.replace(/<br>/g, '').length;
-    let size = Math.max(minSize, Math.min(maxSize, maxSize - largo));
+    const maxDim = Math.min(el.clientWidth, el.clientHeight);
+    let maxSize = Math.min(48, maxDim * 0.8);
+    let size = maxSize;
     el.style.fontSize = size + 'px';
 
-    const maxW = el.clientWidth - 4;
-    const maxH = el.clientHeight - 4;
-
-    // Reducir si se excede
-    while ((el.scrollWidth > maxW || el.scrollHeight > maxH) && size > minSize) {
-      size -= 0.5;
+    while ((el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight) && size > minSize) {
+      size -= 1;
       el.style.fontSize = size + 'px';
     }
 
-    // Aumentar si hay espacio extra
-    while (el.scrollWidth < maxW && el.scrollHeight < maxH && size < maxSize) {
-      size += 0.5;
+    while (el.scrollWidth <= el.clientWidth && el.scrollHeight <= el.clientHeight && size < maxSize) {
+      size += 1;
       el.style.fontSize = size + 'px';
     }
-
-    if (size < minSize) el.style.fontSize = minSize + 'px';
   };
 
-  document.querySelectorAll('.cuadro-icono span').forEach(ajustar);
-  document.querySelectorAll('.flip-card-back').forEach(ajustar);
-  document.querySelectorAll('.tabla-resultados thead th').forEach(ajustar);
+  document.querySelectorAll('.cuadro-icono span, .flip-card-back, .tabla-resultados thead th').forEach(ajustar);
 }
 
 
 window.addEventListener('resize', ajustarTextoCeldas);
+window.addEventListener('load', ajustarTextoCeldas);
 
 function actualizarModalTraducciones() {
   const modal = document.getElementById('modal');

--- a/style.css
+++ b/style.css
@@ -66,6 +66,12 @@ input {
   border-collapse: collapse;
 }
 
+/* Contenedor de la tabla con scroll si excede */
+#contenedor-tabla {
+  width: 100%;
+  overflow: auto;
+}
+
 /* NUEVO: Estilo general para la tabla de resultados */
 .tabla-resultados {
   border-collapse: separate;
@@ -91,7 +97,7 @@ input {
 /* Cabecera (solo aparece una vez) */
 .tabla-resultados thead th {
   color: #ccc;
-  font-size: 1em;
+  font-size: clamp(14px, 2vw, 28px);
   font-weight: normal;
   text-align: center;
   white-space: normal;
@@ -482,10 +488,6 @@ td.arrow-down .flip-card-back::before {
     width: 100%;
     max-width: none;
   }
-  #contenedor-tabla {
-    width: 100%;
-    overflow-x: auto;
-  }
 
 td {
   text-align: center;
@@ -524,6 +526,9 @@ th {
 
 /* Mejor visibilidad para pantallas grandes */
 @media (min-width: 1000px) {
+  .tabla-resultados thead th {
+    font-size: clamp(18px, 2vw, 40px);
+  }
   .tabla-resultados td {
     font-size: clamp(18px, 2vw, 40px);
   }


### PR DESCRIPTION
## Summary
- make result table container scrollable
- increase table header font size and add large-screen rule
- adjust font sizing algorithm for cells
- update text adjustment on window load

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68695995769083338bd281bcb456faeb