### PR TITLE
Fix overflow for long mineral names

### DIFF
--- a/script.js
+++ b/script.js
@@ -429,6 +429,12 @@ function ajustarTextoCeldas() {
     else if (lineas === 1) base *= 1.05;
 
     el.style.fontSize = `${base}px`;
+
+    let size = base;
+    while ((el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight) && size > 8) {
+      size -= 1;
+      el.style.fontSize = `${size}px`;
+    }
   };
 
   document.querySelectorAll('.cuadro-icono span, .flip-card-back, .tabla-resultados thead th').forEach(ajustar);

--- a/style.css
+++ b/style.css
@@ -519,8 +519,8 @@ th {
   font-weight: bold;
   text-align: center;
   white-space: pre-wrap;
-  overflow-wrap: break-word;
-  word-break: break-word;
+  overflow-wrap: normal;
+  word-break: normal;
   line-height: 1.1;
 }
 


### PR DESCRIPTION
## Summary
- adjust text resizing logic to shrink when content overflows
- keep text from breaking inside cells

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68696914bd808333a34b2778c0b611f3