### PR TITLE
Improve table headers and UI features

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
 </head>
 <body>
   <img src="screen/main_logo.png" alt="Logo Minedle" id="main-logo">
-  <h1 id="titulo">Mineraldle</h1>
+  <div id="title-container">
+    <h1 id="titulo">Mineraldle</h1>
+    <button id="hello-btn">?</button>
+  </div>
 
   <div id="language-selector">
     <button onclick="setIdioma('es')">🇪🇸</button>
@@ -33,7 +36,7 @@
   <table class="tabla-resultados" id="tablaResultados">
   <thead>
     <tr>
-      <th></th>
+      <th id="th-mineral">Mineral</th>
       <th id="th-grupo">Grupo</th>
       <th id="th-sistema">Sistema</th>
       <th id="th-color">Color</th>
@@ -61,5 +64,11 @@
   </div>
 
   <div id="fireworks" class="hidden">🎆</div>
+
+  <div id="footer-links">
+    <a href="#" id="twitter-link">Twitter</a>
+    <a href="#" id="kofi-link">Ko-fi</a>
+    <a href="#" id="about-link">About me</a>
+  </div>
 </body>
 </html>

--- a/lang/en.json
+++ b/lang/en.json
@@ -3,8 +3,9 @@
   "input_placeholder": "Type a mineral...",
   "boton_adivinar": "Guess",
   "propiedades": {
+    "mineral": "Mineral",
     "grupo": "Group",
-    "sistema": "Crystal<br>system",
+    "sistema": "Crystal system",
     "color": "Color",
     "brillo": "Luster",
     "dureza": "Hardness",

--- a/lang/es.json
+++ b/lang/es.json
@@ -3,8 +3,9 @@
   "input_placeholder": "Escribe un mineral...",
   "boton_adivinar": "Adivinar",
   "propiedades": {
+    "mineral": "Mineral",
     "grupo": "Grupo",
-    "sistema": "Sistema<br>Cristalino",
+    "sistema": "Sistema Cristalino",
     "color": "Color",
     "brillo": "Brillo",
     "dureza": "Dureza",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -3,6 +3,7 @@
   "input_placeholder": "鉱物の名前を入力...",
   "boton_adivinar": "予想する",
   "propiedades": {
+    "mineral": "鉱物",
     "grupo": "グループ",
     "sistema": "結晶系",
     "color": "色",

--- a/script.js
+++ b/script.js
@@ -79,12 +79,13 @@ function aplicarTraducciones() {
   document.getElementById("inputMineral").placeholder = traducciones.input_placeholder || "Escribe un mineral...";
   document.getElementById("btnAdivinar").innerText = traducciones.boton_adivinar || "Adivinar";
   if (traducciones.propiedades) {
-    document.getElementById("th-grupo").innerHTML = traducciones.propiedades.grupo || "Grupo";
-    document.getElementById("th-sistema").innerHTML = traducciones.propiedades.sistema || "Sistema";
-    document.getElementById("th-color").innerHTML = traducciones.propiedades.color || "Color";
-    document.getElementById("th-brillo").innerHTML = traducciones.propiedades.brillo || "Brillo";
-    document.getElementById("th-dureza").innerHTML = traducciones.propiedades.dureza || "Dureza";
-    document.getElementById("th-densidad").innerHTML = traducciones.propiedades.densidad || "Densidad";
+    document.getElementById("th-mineral").innerText = traducciones.propiedades.mineral || "Mineral";
+    document.getElementById("th-grupo").innerText = traducciones.propiedades.grupo || "Grupo";
+    document.getElementById("th-sistema").innerText = traducciones.propiedades.sistema || "Sistema";
+    document.getElementById("th-color").innerText = traducciones.propiedades.color || "Color";
+    document.getElementById("th-brillo").innerText = traducciones.propiedades.brillo || "Brillo";
+    document.getElementById("th-dureza").innerText = traducciones.propiedades.dureza || "Dureza";
+    document.getElementById("th-densidad").innerText = traducciones.propiedades.densidad || "Densidad";
   }
   document.getElementById("counter-label").innerText =
     (traducciones.mensajes?.intentos_restantes || "Intentos: ");
@@ -116,6 +117,10 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("close-modal").addEventListener("click", () => {
     document.getElementById("modal").classList.add("hidden");
   });
+  const helloBtn = document.getElementById("hello-btn");
+  if (helloBtn) {
+    helloBtn.addEventListener("click", () => alert("Hello World"));
+  }
 });
 
 function iniciarAutocompletado() {
@@ -127,13 +132,13 @@ function iniciarAutocompletado() {
     list.innerHTML = "";
     if (!val) return;
 
-    const coincidencias = minerales.filter(m =>
-      m.nombre.toLowerCase().includes(val)
-    );
+    const coincidencias = minerales
+      .filter(m => m.nombre.toLowerCase().includes(val))
+      .sort((a, b) => a.nombre.localeCompare(b.nombre));
 
     coincidencias.forEach(mineral => {
       const li = document.createElement("li");
-      li.textContent = mineral.nombre;
+      li.innerHTML = `<img src="img/${mineral.nombre.toLowerCase()}.png" alt="${traducirValor(mineral.nombre)}"> <span>${traducirValor(mineral.nombre)}</span>`;
       li.addEventListener("click", () => {
         input.value = mineral.nombre;
         list.innerHTML = "";
@@ -256,8 +261,7 @@ async function intentarAdivinar() {
 
   setTimeout(() => {
   document.querySelectorAll("#pistas td.texto-auto").forEach(td => {
-    // Extrae texto, ajusta tamaño en función del número de líneas Y ancho
-    const contentLines = td.innerHTML.split("<br>").length;
+    const contentLines = 1;
     const width = td.offsetWidth;
 
     let base = 20; // px
@@ -333,7 +337,7 @@ function comparar(valor, objetivo) {
   const val = Array.isArray(valor) ? valor.map(v => v.toLowerCase()) : [valor.toLowerCase()];
   const obj = Array.isArray(objetivo) ? objetivo.map(o => o.toLowerCase()) : [objetivo.toLowerCase()];
   const coincidencias = val.filter(v => obj.includes(v));
-  const texto = (Array.isArray(valor) ? valor : valor.split(",")).map(v => v.trim()).join("<br>");
+  const texto = (Array.isArray(valor) ? valor : valor.split(",")).map(v => v.trim()).join(", ");
 
   let clase = "rojo";
   if (coincidencias.length === obj.length && val.length === obj.length) {
@@ -420,11 +424,11 @@ function ajustarTextoCeldas() {
     let texto = el.textContent.trim();
 
     if (texto.includes(',')) {
-      el.innerHTML = texto.split(',').map(p => p.trim()).join('<br>');
+      el.innerHTML = texto.split(',').map(p => p.trim()).join(', ');
       texto = el.textContent.trim();
     }
 
-    const lineas = el.innerHTML.split('<br>').length;
+    const lineas = 1;
     const width = el.offsetWidth;
     const len = texto.length;
 

--- a/style.css
+++ b/style.css
@@ -16,6 +16,17 @@ h1 {
   color: #00e676;
 }
 
+#title-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+#hello-btn {
+  padding: 0.3em 0.6em;
+  font-size: 1em;
+}
+
 #main-logo {
   width: 100%;
   height: auto;
@@ -104,6 +115,7 @@ input {
   text-align: center;
   white-space: normal;
   word-break: break-word;
+  overflow-wrap: anywhere;
   padding-bottom: 0.3em;
   border: none;
   width: 100px;
@@ -180,6 +192,8 @@ input {
   text-transform: uppercase;
   padding-top: 1.2em;
   overflow: hidden;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .flip-card-back::after {
@@ -237,8 +251,9 @@ td.arrow-down .flip-card-back::before {
 
 .numero-intento {
   position: absolute;
-  top: 4px;
-  left: 4px;
+  left: -16px;
+  top: 50%;
+  transform: translateY(-50%);
   width: 28px;
   height: 28px;
   font-size: 1rem;
@@ -338,6 +353,9 @@ td.arrow-down .flip-card-back::before {
   border-bottom: 1px solid #eee;
   transition: background 0.2s ease;
   margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .autocomplete-items li:hover {
@@ -347,6 +365,13 @@ td.arrow-down .flip-card-back::before {
 .autocomplete-items li:last-child {
   border-bottom: none;
   margin-bottom: 0;
+}
+
+.autocomplete-items li img {
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+  border-radius: 4px;
 }
 
 #autocomplete-list,
@@ -455,6 +480,18 @@ td.arrow-down .flip-card-back::before {
   display: none;
 }
 
+#footer-links {
+  display: flex;
+  gap: 1em;
+  margin-top: 2em;
+}
+
+#footer-links a {
+  color: #00e676;
+  text-decoration: none;
+  font-weight: bold;
+}
+
 .modal-content {
   background: #2a2a2a;
   padding: 1em 2em;
@@ -533,9 +570,9 @@ th {
   padding: 4px;
   font-weight: bold;
   text-align: center;
-  white-space: pre-wrap;
-  overflow-wrap: normal;
-  word-break: normal;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   line-height: 1.1;
   text-transform: uppercase;
   padding-top: calc(1.2em + 4px);


### PR DESCRIPTION
## Summary
- add title container with a `Hello World` button
- show "Mineral" header column using translations
- sort autocomplete alphabetically and show mineral images
- position try counter outside the image frame
- enable better text wrapping and remove `<br>` usage
- add footer links

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686999aad74c8333b46fbe3293578118