### PR TITLE
UI tweaks for desktop view

### DIFF
--- a/script.js
+++ b/script.js
@@ -246,6 +246,7 @@ async function intentarAdivinar() {
   cuerpo.insertBefore(fila, cuerpo.firstChild);
   ajustarTextoCeldas();
   await revealRow(fila);
+  ajustarTextoCeldas();
 
   const gano = mineral.nombre === mineralDelDia.nombre;
   if (gano || intentos >= maxIntentos) {

--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@ h1 {
 #main-logo {
   width: 100%;
   height: auto;
-  max-width: 250px;
+  max-width: 270px;
   margin-bottom: 0.5em;
   object-fit: contain;
 }
@@ -80,7 +80,7 @@ input {
 /* Contenedor de la tabla con scroll si excede */
 #contenedor-tabla {
   width: 100%;
-  overflow-x: hidden;
+  overflow-x: visible;
   display: flex;
   justify-content: center;
 }
@@ -128,6 +128,22 @@ input {
   overflow: hidden;
   border-radius: 6px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+
+@media (min-width: 600px) {
+  .tabla-resultados thead th {
+    width: auto;
+    min-width: auto;
+    max-width: none;
+    height: auto;
+    min-height: auto;
+    max-height: none;
+    aspect-ratio: auto;
+    padding: 0.5em 1em;
+    box-shadow: none;
+    border-bottom: 2px solid #444;
+    font-size: 1.4em;
+  }
 }
 
 /* Celdas */
@@ -252,7 +268,7 @@ td.arrow-down .flip-card-back::before {
 
 .numero-intento {
   position: absolute;
-  left: -16px;
+  left: -40px;
   top: 50%;
   transform: translateY(-50%);
   width: 28px;


### PR DESCRIPTION
## Summary
- enlarge main logo
- allow overflow around the results table
- keep attempt number badge outside result cell
- desktop table headers now bigger, no square background and underlined
- recalc text sizes after row reveal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869b0179e9083338c77be57ad32ce7f