### PR TITLE
Fix result square aspect ratio

### DIFF
--- a/style.css
+++ b/style.css
@@ -264,6 +264,7 @@ td.arrow-down .flip-card-back::before {
   min-height: 100px;
   max-width: 100px;
   max-height: 100px;
+  aspect-ratio: 1 / 1;
 }
 
 .numero-intento {


### PR DESCRIPTION
## Summary
- keep the icon container in each table cell square using `aspect-ratio`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869c255cc5883338ed49c02198b0952