### PR TITLE
Fix attempt number visibility and adjust font scaling

### DIFF
--- a/script.js
+++ b/script.js
@@ -459,7 +459,7 @@ function ajustarTextoCeldas() {
 
     let estilo = `${fontBase}${size}px ${comp.fontFamily}`;
     let maxWidth = Math.max(...lineas.map(l => medirTexto(l, estilo)));
-    while (maxWidth > ancho && size > 8) {
+    while (maxWidth > ancho && size > 6) {
       size -= 1;
       estilo = `${fontBase}${size}px ${comp.fontFamily}`;
       maxWidth = Math.max(...lineas.map(l => medirTexto(l, estilo)));

--- a/style.css
+++ b/style.css
@@ -169,6 +169,10 @@ input {
   text-transform: none;
 }
 
+.tabla-resultados td.imagen-nombre {
+  overflow: visible;
+}
+
 /* Flip card effect */
 .flip-card {
   perspective: 600px;


### PR DESCRIPTION
## Summary
- allow font scaling down to 6px to prevent long mineral names from being cut off
- ensure attempt numbers are visible by overriding overflow for image name cells

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6869e641f2088333a71fd0ea4a2e6ed5