### PR TITLE
Fix header font sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,7 +124,7 @@ input {
   background-color: transparent;
   width: 85px;
   height: 85px;
-  font-size: clamp(14px, 4vw, 32px);
+  font-size: clamp(8px, 2.5vw, 26px);
   line-height: 1.2;
   overflow-wrap: break-word;
   word-break: break-word;
@@ -142,7 +142,7 @@ input {
     padding: 0.5em 1em;
     box-shadow: none;
     border-bottom: 4px solid white;
-    font-size: clamp(16px, 2vw, 32px);
+    font-size: clamp(8px, 2.5vw, 26px);
   }
 }
 
@@ -415,7 +415,7 @@ td.arrow-down .flip-card-back::before {
     aspect-ratio: 1 / 1;
   }
   .tabla-resultados thead th {
-    font-size: clamp(12px, 5vw, 26px);
+    font-size: clamp(10px, 4vw, 22px);
     white-space: normal;
     word-break: normal;
     overflow-wrap: break-word;


### PR DESCRIPTION
## Summary
- adjust column header font sizes to match table cell font scaling

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869ec3c9dec8333b3bf39ea1f9acf4b