### PR TITLE
Fix header text scaling

### DIFF
--- a/script.js
+++ b/script.js
@@ -447,6 +447,7 @@ function ajustarTextoCeldas() {
     const fontBase = `${comp.fontStyle} ${comp.fontVariant} ${comp.fontWeight} `;
     const padding = parseFloat(comp.paddingLeft) + parseFloat(comp.paddingRight);
     const ancho = el.clientWidth - padding;
+    if (ancho <= 0) return; // Skip if element is hidden
 
     const obtenerLineas = html =>
       html


### PR DESCRIPTION
## Summary
- avoid shrinking hidden table headers by skipping adjustment when width is zero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aaffc69648333a3f068c559ce8d64