### PR TITLE
Add confetti on win

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
   </div>
 
   <div id="fireworks" class="hidden">🎆</div>
+  <canvas id="confetti-canvas" class="hidden"></canvas>
 
   <div id="footer-links">
     <a href="#" id="twitter-link">Twitter</a>

--- a/script.js
+++ b/script.js
@@ -46,12 +46,59 @@ function mostrarModal(gano) {
   document.getElementById("modal-intentos").innerText =
     (traducciones.mensajes?.intentos || "Intentos:") + " " + intentos;
   modal.classList.remove("hidden");
+  if (gano) confettiExplosion();
 }
 
 function mostrarFuegos() {
   const fw = document.getElementById("fireworks");
   fw.classList.remove("hidden");
   setTimeout(() => fw.classList.add("hidden"), 2000);
+}
+
+function confettiExplosion() {
+  const canvas = document.getElementById('confetti-canvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  canvas.classList.remove('hidden');
+
+  const particles = [];
+  for (let i = 0; i < 120; i++) {
+    particles.push({
+      x: canvas.width / 2,
+      y: canvas.height / 2,
+      vx: (Math.random() - 0.5) * 10,
+      vy: (Math.random() - 0.7) * 10,
+      size: Math.random() * 6 + 4,
+      color: `hsl(${Math.random() * 360},100%,50%)`,
+      life: 80 + Math.random() * 20
+    });
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    particles.forEach(p => {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vy += 0.2;
+      p.life--;
+      ctx.fillStyle = p.color;
+      ctx.fillRect(p.x, p.y, p.size, p.size);
+    });
+    for (let i = particles.length - 1; i >= 0; i--) {
+      if (particles[i].life <= 0 || particles[i].y > canvas.height) {
+        particles.splice(i, 1);
+      }
+    }
+    if (particles.length) {
+      requestAnimationFrame(draw);
+    } else {
+      canvas.classList.add('hidden');
+    }
+  }
+
+  requestAnimationFrame(draw);
 }
 
 function traducirValor(valor) {

--- a/style.css
+++ b/style.css
@@ -476,6 +476,16 @@ td.arrow-down .flip-card-back::before {
   z-index: 1500;
 }
 
+#confetti-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2500;
+}
+
 @keyframes fadeOut {
   0% { opacity: 1; }
   100% { opacity: 0; }
@@ -500,7 +510,8 @@ td.arrow-down .flip-card-back::before {
 }
 
 #modal.hidden,
-#fireworks.hidden {
+#fireworks.hidden,
+#confetti-canvas.hidden {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- show a transparent confetti canvas when the player wins
- style the confetti canvas and hide it by default

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b8ff88d9083338d8dfa7a0374235b