### PR TITLE
Fix footer links and phone scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,7 @@
   <canvas id="confetti-canvas" class="hidden"></canvas>
 
   <div id="footer-links">
-    <a href="#" id="twitter-link">Twitter</a>
-    <a href="#" id="kofi-link">Ko-fi</a>
+    <a href="https://x.com/AzaleaDevs" id="twitter-link" target="_blank">Twitter</a>
+    <a href="https://ko-fi.com/azaleadevs" id="kofi-link" target="_blank">Ko-fi</a>
     <a href="#" id="about-link">About me</a>
-  </div>
-</body></html>
+  </div></body></html>

--- a/script.js
+++ b/script.js
@@ -353,6 +353,7 @@ fila.appendChild(
 
   const cuerpo = document.getElementById("tabla-cuerpo");
   cuerpo.insertBefore(fila, cuerpo.firstChild);
+  document.getElementById('contenedor-tabla').scrollLeft = 0;
   ajustarTextoCeldas();
   await revealRow(fila);
   ajustarTextoCeldas();

--- a/style.css
+++ b/style.css
@@ -83,12 +83,13 @@ input {
   width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
-  padding-left: 0;
+  padding-left: 2.5em;
   padding-right: 0;
   margin: 0 auto;
   box-sizing: border-box;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
+  scroll-behavior: smooth;
 }
 
 /* NUEVO: Estilo general para la tabla de resultados */


### PR DESCRIPTION
## Summary
- update Twitter and Ko-fi URLs
- keep results table scrolled to the left when adding new attempts
- adjust table container padding and alignment for phone screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686daa707a4883338ebd83cfc9b46dd0