### PR TITLE
Fix table position, subtitle placement and add gem background

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
 <body>
   <img src="screen/main_logo.png" alt="Logo Minedle" id="main-logo">
   <div id="title-container">
-    <h1 id="titulo">Mineraldle</h1>
     <button id="hello-btn">?</button>
     <select id="language-select">
       <option value="es">🇪🇸 Español</option>
@@ -21,6 +20,7 @@
       <option value="ja">🇯🇵 日本語</option>
     </select>
   </div>
+  <h1 id="titulo">Mineraldle</h1>
 
   <div id="form-container">
     <div id="counter"><span id="counter-label"></span><span id="counter-value"></span></div>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,11 @@
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #1e1e1e;
+  background-image: url('screen/background_gems.png');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   color: #ffffff;
   font-size: 18px;
   display: flex;
@@ -86,12 +91,12 @@ input {
   width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
-  padding-left: 2.5em;
+  padding-left: 0;
   padding-right: 0;
   margin: 0 auto;
   box-sizing: border-box;
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   scroll-behavior: smooth;
 }
 
@@ -673,5 +678,4 @@ th {
     object-fit: contain;
   }
 
-
-}}
+}


### PR DESCRIPTION
## Summary
- center the results table container
- show the heading after the language/`?` controls
- apply a fullscreen gem background image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687017258be08333adc7e4869af4ea56