### PR TITLE
Fix mobile table alignment and header

### DIFF
--- a/style.css
+++ b/style.css
@@ -418,6 +418,13 @@ td.arrow-down .flip-card-back::before {
   h1 {
     font-size: 2em;
   }
+  #titulo {
+    white-space: nowrap;
+    font-size: 1.8em;
+  }
+  #contenedor-tabla {
+    justify-content: flex-start;
+  }
   /* Make result cells bigger on small screens */
   .tabla-resultados thead th,
   .tabla-resultados td,


### PR DESCRIPTION
## Summary
- ensure the header text stays on one line on small screens
- left-align the results table when viewed on mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6870357228fc8333bfa0cd846c5f568a