### PR TITLE
Fix flags in language selector and enlarge how-to button

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,6 +9,19 @@ let cabeceraMostrada = false;
 let ultimoResultado = null;
 let timerInterval = null;
 
+const flagPaths = {
+  es: 'screen/spain_flag.png',
+  eu: 'screen/euskera_flag.png',
+  gl: 'screen/galicia_flag.png',
+  ca: 'screen/catalonia_flag.png',
+  fr: 'screen/france_flag.png',
+  en: 'screen/uk_flag.png',
+  de: 'screen/germany_flag.png',
+  ja: 'screen/japan_flag.png',
+  zh: 'screen/china_flag.png',
+  ko: 'screen/korea_flag.png'
+};
+
 function updateTimer() {
   const now = new Date();
   const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
@@ -193,7 +206,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const langSelect = document.getElementById('language-select');
   if (langSelect) {
     langSelect.value = guardado;
-    langSelect.addEventListener('change', e => setIdioma(e.target.value));
+    updateSelectFlag(langSelect.value);
+    langSelect.addEventListener('change', e => {
+      updateSelectFlag(e.target.value);
+      setIdioma(e.target.value);
+    });
   }
   updateCounter();
   updateTimer();
@@ -654,4 +671,16 @@ function compartirEnTwitter(e) {
     navigator.clipboard.writeText(texto).catch(() => {});
   }
   window.open(url, '_blank', 'noopener');
+}
+
+function updateSelectFlag(lang) {
+  const select = document.getElementById('language-select');
+  if (!select) return;
+  const path = flagPaths[lang];
+  if (path) {
+    select.style.backgroundImage = `url(${path})`;
+    select.style.backgroundRepeat = 'no-repeat';
+    select.style.backgroundPosition = 'center left';
+    select.style.paddingLeft = '1.6em';
+  }
 }

--- a/style.css
+++ b/style.css
@@ -35,8 +35,9 @@ h1 {
 }
 
 #hello-btn img {
-  height: 32px;
-  width: 32px;
+  /* enlarge the how-to button by 50% */
+  height: 48px;
+  width: 48px;
 }
 
 #main-logo {
@@ -56,11 +57,15 @@ h1 {
 }
 
 #language-select option {
+  /* ensure flag icons are visible */
   font-size: 0;
   padding-left: 1.6em;
   background-repeat: no-repeat;
   background-size: contain;
   background-position: center left;
+  display: block;
+  height: 1.7em;
+  line-height: 1.7em;
 }
 
 #language-select .flag-es { background-image: url("screen/spain_flag.png"); }


### PR DESCRIPTION
## Summary
- enlarge the help icon 50%
- make language flags visible inside the dropdown
- show the current flag on the select element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687045b8d30883338ac1ec0ce8680d0a