### PR TITLE
Improve table header sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -163,8 +163,8 @@ input {
   padding: 0.4em;
   border-bottom: 4px solid white;
   background-color: transparent;
-  width: 85px;
-  height: 85px;
+  width: clamp(85px, 10vw, 120px);
+  height: clamp(85px, 10vw, 120px);
   font-size: clamp(16px, 2.5vw, 34px);
   line-height: 1.2;
   overflow-wrap: break-word;
@@ -173,13 +173,6 @@ input {
 
 @media (min-width: 600px) {
   .tabla-resultados thead th {
-    width: auto;
-    min-width: auto;
-    max-width: none;
-    height: auto;
-    min-height: auto;
-    max-height: none;
-    aspect-ratio: auto;
     padding: 0.5em 1em;
     box-shadow: none;
     border-bottom: 4px solid white;
@@ -189,12 +182,12 @@ input {
 
 /* Celdas */
 .tabla-resultados td {
-  width: 85px;
-  height: 85px;
+  width: clamp(85px, 10vw, 120px);
+  height: clamp(85px, 10vw, 120px);
   min-width: 85px;
   min-height: 85px;
-  max-width: 85px;
-  max-height: 85px;
+  max-width: 120px;
+  max-height: 120px;
   aspect-ratio: 1 / 1;
   border: 1px solid #000;
   border-radius: 6px;
@@ -298,8 +291,8 @@ td.arrow-down .flip-card-back::before {
 }
 
 .imagen-nombre img {
-  width: 85px;
-  height: 85px;
+  width: 100%;
+  height: 100%;
   object-fit: contain;
 }
 
@@ -460,12 +453,6 @@ td.arrow-down .flip-card-back::before {
   .tabla-resultados thead th,
   .tabla-resultados td,
   .cuadro-icono {
-    width: 85px;
-    min-width: 85px;
-    max-width: 85px;
-    height: 85px;
-    min-height: 85px;
-    max-height: 85px;
     aspect-ratio: 1 / 1;
   }
   .tabla-resultados thead th {


### PR DESCRIPTION
## Summary
- make header cells flexible
- use clamp() sizing on data cells
- scale mineral images with their container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68704a4984c88333ba456f3cfe3667e4