### PR TITLE
Fix desktop modal size and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# mineraldle
+# Mineraldle
+
+## A daily mineral guessing game
+
+Mineraldle challenges you to discover the mineral of the day using a limited number of guesses. Each attempt reveals hints about the mineral's group, system, color, luster, hardness and density.
+
+### Features
+
+- **Daily challenge** with countdown timer to the next mineral
+- **Autocomplete** input to help you pick valid minerals
+- **Shareable results** with a built in Twitter link
+- **Responsive design** that works great on phones and desktops
+- **Multilingual** interface (Catalan, German, English, Basque, Spanish, French, Galician, Japanese, Chinese and Korean)
+
+### How to play
+
+1. Start typing a mineral name and select one of the suggestions.
+2. Press **Adivinar** to submit your guess.
+3. Correct properties are highlighted after each try.
+4. When the game ends you'll see a summary window with the mineral image and your attempt count.
+
+### Local setup
+
+Clone the repository and open `index.html` in your favourite browser:
+
+```bash
+ git clone <repo_url>
+ cd mineraldle
+```
+
+### Screenshots
+
+![Logo](screen/main_logo.png)
+
+![How to play](screen/howto.png)
+
+Enjoy and feel free to contribute!
+

--- a/style.css
+++ b/style.css
@@ -609,6 +609,13 @@ td.arrow-down .flip-card-back::before {
   text-align: center;
 }
 
+@media (min-width: 600px) {
+  .modal-content {
+    width: 80%;
+    max-width: 600px;
+  }
+}
+
 .modal-content img {
   width: 100%;
   height: auto;


### PR DESCRIPTION
## Summary
- limit modal size on larger screens so it doesn't occupy the whole page
- rewrite README with an overview, features, how to play and screenshots

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687103e396908333893bfe3e538cae64